### PR TITLE
Initial conversion for IPFS datastore interface

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -33,15 +33,15 @@ type Collection struct {
 	Contents [][]string `json:"contents,omitempty"`
 }
 
-func (c *Collection) DatastoreType() string {
+func (c Collection) DatastoreType() string {
 	return "Collection"
 }
 
-func (c *Collection) GetId() string {
+func (c Collection) GetId() string {
 	return c.Id
 }
 
-func (c *Collection) Key() datastore.Key {
+func (c Collection) Key() datastore.Key {
 	return datastore.NewKey(fmt.Sprintf("%s:%s", c.DatastoreType(), c.GetId()))
 }
 
@@ -84,7 +84,6 @@ func (c *Collection) Save(store datastore.Datastore) (err error) {
 
 // Delete a collection, should only do for erronious additions
 func (c *Collection) Delete(store datastore.Datastore) error {
-	// _, err := db.Exec(qCollectionDelete, c.Id)
 	return store.Delete(c.Key())
 }
 
@@ -117,6 +116,8 @@ func (c *Collection) SQLParams(cmd sqlutil.CmdType) []interface{} {
 	switch cmd {
 	case sqlutil.CmdSelectOne, sqlutil.CmdExistsOne, sqlutil.CmdDeleteOne:
 		return []interface{}{c.Id}
+	case sqlutil.CmdList:
+		return nil
 	default:
 		schemaBytes, err := json.Marshal(c.Schema)
 		if err != nil {

--- a/collection.go
+++ b/collection.go
@@ -88,8 +88,10 @@ func (c *Collection) Delete(store datastore.Datastore) error {
 	return store.Delete(c.Key())
 }
 
-func (c Collection) NewSQLModel(id string) sql_datastore.Model {
-	return &Collection{Id: id}
+func (c *Collection) NewSQLModel(id string) sql_datastore.Model {
+	return &Collection{
+		Id: id,
+	}
 }
 
 func (c Collection) SQLQuery(cmd sql_datastore.Cmd) string {

--- a/collection.go
+++ b/collection.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"github.com/archivers-space/sql_datastore"
 	"github.com/archivers-space/sqlutil"
 	datastore "github.com/ipfs/go-datastore"
 	"github.com/pborman/uuid"
@@ -87,36 +88,36 @@ func (c *Collection) Delete(store datastore.Datastore) error {
 	return store.Delete(c.Key())
 }
 
-func (c Collection) NewSQLModel(id string) sqlutil.Model {
+func (c Collection) NewSQLModel(id string) sql_datastore.Model {
 	return &Collection{Id: id}
 }
 
-func (c Collection) SQLQuery(cmd sqlutil.CmdType) string {
+func (c Collection) SQLQuery(cmd sql_datastore.Cmd) string {
 	switch cmd {
-	case sqlutil.CmdCreateTable:
+	case sql_datastore.CmdCreateTable:
 		return qCollectionCreateTable
-	case sqlutil.CmdExistsOne:
+	case sql_datastore.CmdExistsOne:
 		return qCollectionExists
-	case sqlutil.CmdSelectOne:
+	case sql_datastore.CmdSelectOne:
 		return qCollectionById
-	case sqlutil.CmdInsertOne:
+	case sql_datastore.CmdInsertOne:
 		return qCollectionInsert
-	case sqlutil.CmdUpdateOne:
+	case sql_datastore.CmdUpdateOne:
 		return qCollectionUpdate
-	case sqlutil.CmdDeleteOne:
+	case sql_datastore.CmdDeleteOne:
 		return qCollectionDelete
-	case sqlutil.CmdList:
+	case sql_datastore.CmdList:
 		return qCollections
 	default:
 		return ""
 	}
 }
 
-func (c *Collection) SQLParams(cmd sqlutil.CmdType) []interface{} {
+func (c *Collection) SQLParams(cmd sql_datastore.Cmd) []interface{} {
 	switch cmd {
-	case sqlutil.CmdSelectOne, sqlutil.CmdExistsOne, sqlutil.CmdDeleteOne:
+	case sql_datastore.CmdSelectOne, sql_datastore.CmdExistsOne, sql_datastore.CmdDeleteOne:
 		return []interface{}{c.Id}
-	case sqlutil.CmdList:
+	case sql_datastore.CmdList:
 		return nil
 	default:
 		schemaBytes, err := json.Marshal(c.Schema)

--- a/collection_test.go
+++ b/collection_test.go
@@ -1,26 +1,28 @@
 package archive
 
 import (
+	"github.com/archivers-space/sql_datastore"
+	"github.com/ipfs/go-datastore"
 	"testing"
 )
 
 func TestCollectionStorage(t *testing.T) {
-	defer resetTestData(appDB, "collections")
+	ds := datastore.NewMapDatastore()
 
 	c := &Collection{Title: "test collection"}
-	if err := c.Save(appDB); err != nil {
+	if err := c.Save(ds); err != nil {
 		t.Error(err.Error())
 		return
 	}
 
 	c.Creator = "penelope"
-	if err := c.Save(appDB); err != nil {
+	if err := c.Save(ds); err != nil {
 		t.Error(err.Error())
 		return
 	}
 
 	c2 := &Collection{Id: c.Id}
-	if err := c2.Read(appDB); err != nil {
+	if err := c2.Read(ds); err != nil {
 		t.Error(err.Error())
 		return
 	}
@@ -33,7 +35,48 @@ func TestCollectionStorage(t *testing.T) {
 		t.Errorf("updated doesn't match: %s != %s", c2.Updated.String(), c.Updated.String())
 	}
 
-	if err := c.Delete(appDB); err != nil {
+	if err := c.Delete(ds); err != nil {
+		t.Error(err.Error())
+		return
+	}
+}
+
+func TestCollectionSQLStorage(t *testing.T) {
+	defer resetTestData(appDB, "collections")
+
+	store := sql_datastore.NewDatastore(appDB)
+	if err := store.Register(&Collection{}); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	c := &Collection{Title: "test collection"}
+	if err := c.Save(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	c.Creator = "penelope"
+	if err := c.Save(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	c2 := &Collection{Id: c.Id}
+	if err := c2.Read(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	if !c2.Created.Equal(c.Created) {
+		t.Errorf("created doesn't match: %s != %s", c2.Created.String(), c.Created.String())
+	}
+
+	if !c2.Updated.Equal(c.Updated) {
+		t.Errorf("updated doesn't match: %s != %s", c2.Updated.String(), c.Updated.String())
+	}
+
+	if err := c.Delete(store); err != nil {
 		t.Error(err.Error())
 		return
 	}

--- a/collection_test.go
+++ b/collection_test.go
@@ -7,22 +7,22 @@ import (
 )
 
 func TestCollectionStorage(t *testing.T) {
-	ds := datastore.NewMapDatastore()
+	store := datastore.NewMapDatastore()
 
 	c := &Collection{Title: "test collection"}
-	if err := c.Save(ds); err != nil {
+	if err := c.Save(store); err != nil {
 		t.Error(err.Error())
 		return
 	}
 
 	c.Creator = "penelope"
-	if err := c.Save(ds); err != nil {
+	if err := c.Save(store); err != nil {
 		t.Error(err.Error())
 		return
 	}
 
 	c2 := &Collection{Id: c.Id}
-	if err := c2.Read(ds); err != nil {
+	if err := c2.Read(store); err != nil {
 		t.Error(err.Error())
 		return
 	}
@@ -35,7 +35,7 @@ func TestCollectionStorage(t *testing.T) {
 		t.Errorf("updated doesn't match: %s != %s", c2.Updated.String(), c.Updated.String())
 	}
 
-	if err := c.Delete(ds); err != nil {
+	if err := c.Delete(store); err != nil {
 		t.Error(err.Error())
 		return
 	}

--- a/collections_test.go
+++ b/collections_test.go
@@ -1,15 +1,30 @@
 package archive
 
 import (
+	"github.com/archivers-space/sql_datastore"
 	"testing"
 )
 
 func TestListCollections(t *testing.T) {
-	collections, err := ListCollections(appDB, 20, 0)
+	store := sql_datastore.NewDatastore(appDB)
+	if err := store.Register(&Collection{}); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	collections, err := ListCollections(store, 20, 0)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
 	if len(collections) != 1 {
+		t.Errorf("collections length mismatch")
+	}
+
+	collections, err = ListCollections(store, 20, 1)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if len(collections) != 0 {
 		t.Errorf("collections length mismatch")
 	}
 }

--- a/datarepo.go
+++ b/datarepo.go
@@ -80,8 +80,10 @@ func (d *DataRepo) Delete(store datastore.Datastore) error {
 	return store.Delete(d.Key())
 }
 
-func (d DataRepo) NewSQLModel(id string) sql_datastore.Model {
-	return &DataRepo{Id: id}
+func (d *DataRepo) NewSQLModel(id string) sql_datastore.Model {
+	return &DataRepo{
+		Id: id,
+	}
 }
 
 func (d DataRepo) SQLQuery(cmd sql_datastore.Cmd) string {

--- a/datarepo.go
+++ b/datarepo.go
@@ -3,6 +3,7 @@ package archive
 import (
 	"database/sql"
 	"fmt"
+	"github.com/archivers-space/sql_datastore"
 	"github.com/archivers-space/sqlutil"
 	"github.com/ipfs/go-datastore"
 	"github.com/pborman/uuid"
@@ -79,34 +80,34 @@ func (d *DataRepo) Delete(store datastore.Datastore) error {
 	return store.Delete(d.Key())
 }
 
-func (d DataRepo) NewSQLModel(id string) sqlutil.Model {
+func (d DataRepo) NewSQLModel(id string) sql_datastore.Model {
 	return &DataRepo{Id: id}
 }
 
-func (d DataRepo) SQLQuery(cmd sqlutil.CmdType) string {
+func (d DataRepo) SQLQuery(cmd sql_datastore.Cmd) string {
 	switch cmd {
-	case sqlutil.CmdCreateTable:
+	case sql_datastore.CmdCreateTable:
 		return qDataRepoCreateTable
-	case sqlutil.CmdExistsOne:
+	case sql_datastore.CmdExistsOne:
 		return qDataRepoExists
-	case sqlutil.CmdSelectOne:
+	case sql_datastore.CmdSelectOne:
 		return qDataRepoById
-	case sqlutil.CmdInsertOne:
+	case sql_datastore.CmdInsertOne:
 		return qDataRepoInsert
-	case sqlutil.CmdUpdateOne:
+	case sql_datastore.CmdUpdateOne:
 		return qDataRepoUpdate
-	case sqlutil.CmdDeleteOne:
+	case sql_datastore.CmdDeleteOne:
 		return qDataRepoDelete
-	case sqlutil.CmdList:
+	case sql_datastore.CmdList:
 		return qDataRepos
 	default:
 		return ""
 	}
 }
 
-func (d DataRepo) SQLParams(cmd sqlutil.CmdType) []interface{} {
+func (d DataRepo) SQLParams(cmd sql_datastore.Cmd) []interface{} {
 	switch cmd {
-	case sqlutil.CmdSelectOne, sqlutil.CmdExistsOne, sqlutil.CmdDeleteOne:
+	case sql_datastore.CmdSelectOne, sql_datastore.CmdExistsOne, sql_datastore.CmdDeleteOne:
 		return []interface{}{d.Id}
 	default:
 		return []interface{}{

--- a/datarepo_test.go
+++ b/datarepo_test.go
@@ -1,26 +1,28 @@
 package archive
 
 import (
+	"github.com/archivers-space/sql_datastore"
+	"github.com/ipfs/go-datastore"
 	"testing"
 )
 
 func TestDataRepoStorage(t *testing.T) {
-	defer resetTestData(appDB, "dataRepos")
+	store := datastore.NewMapDatastore()
 
 	c := &DataRepo{Title: "test dataRepo"}
-	if err := c.Save(appDB); err != nil {
+	if err := c.Save(store); err != nil {
 		t.Error(err.Error())
 		return
 	}
 
 	c.Description = "test description!"
-	if err := c.Save(appDB); err != nil {
+	if err := c.Save(store); err != nil {
 		t.Error(err.Error())
 		return
 	}
 
 	c2 := &DataRepo{Id: c.Id}
-	if err := c2.Read(appDB); err != nil {
+	if err := c2.Read(store); err != nil {
 		t.Error(err.Error())
 		return
 	}
@@ -33,7 +35,48 @@ func TestDataRepoStorage(t *testing.T) {
 		t.Errorf("updated doesn't match: %s != %s", c2.Updated.String(), c.Updated.String())
 	}
 
-	if err := c.Delete(appDB); err != nil {
+	if err := c.Delete(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+}
+
+func TestDataRepoSQLStorage(t *testing.T) {
+	defer resetTestData(appDB, "dataRepos")
+
+	store := sql_datastore.NewDatastore(appDB)
+	if err := store.Register(&DataRepo{}); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	c := &DataRepo{Title: "test dataRepo"}
+	if err := c.Save(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	c.Description = "test description!"
+	if err := c.Save(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	c2 := &DataRepo{Id: c.Id}
+	if err := c2.Read(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	if !c2.Created.Equal(c.Created) {
+		t.Errorf("created doesn't match: %s != %s", c2.Created.String(), c.Created.String())
+	}
+
+	if !c2.Updated.Equal(c.Updated) {
+		t.Errorf("updated doesn't match: %s != %s", c2.Updated.String(), c.Updated.String())
+	}
+
+	if err := c.Delete(store); err != nil {
 		t.Error(err.Error())
 		return
 	}

--- a/errors.go
+++ b/errors.go
@@ -3,5 +3,6 @@ package archive
 import "fmt"
 
 var (
-	ErrNotFound = fmt.Errorf("Not Found")
+	ErrNotFound        = fmt.Errorf("Not Found")
+	ErrInvalidResponse = fmt.Errorf("Datastore returned an invalid response")
 )

--- a/file.go
+++ b/file.go
@@ -16,6 +16,7 @@ import (
 
 // File is a buffered byte slice often made from a GET response body.
 // It provides easy hash-calculation & storage to S3
+// TODO - depricate, use s3-datastore, or, uh... the distributed web
 type File struct {
 	Url  string
 	Data []byte

--- a/link.go
+++ b/link.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"github.com/archivers-space/sql_datastore"
 	"github.com/archivers-space/sqlutil"
 	"github.com/ipfs/go-datastore"
 	"github.com/multiformats/go-multihash"
@@ -100,28 +101,28 @@ func (l *Link) calcHash() {
 	l.Hash = hex.EncodeToString(mhBuf)
 }
 
-func (l Link) NewSQLModel(id string) sqlutil.Model {
+func (l Link) NewSQLModel(id string) sql_datastore.Model {
 	return &Link{Hash: id}
 }
 
-func (l *Link) SQLQuery(cmd sqlutil.CmdType) string {
+func (l *Link) SQLQuery(cmd sql_datastore.Cmd) string {
 	switch cmd {
-	case sqlutil.CmdCreateTable:
+	case sql_datastore.CmdCreateTable:
 		return qLinkCreateTable
-	case sqlutil.CmdExistsOne:
+	case sql_datastore.CmdExistsOne:
 		return qLinkExists
-	case sqlutil.CmdInsertOne:
+	case sql_datastore.CmdInsertOne:
 		return qLinkInsert
-	case sqlutil.CmdDeleteOne:
+	case sql_datastore.CmdDeleteOne:
 		return qLinkDelete
-	case sqlutil.CmdUpdateOne:
+	case sql_datastore.CmdUpdateOne:
 		return qLinkUpdate
 	default:
 		return ""
 	}
 }
 
-func (l *Link) SQLParams(cmd sqlutil.CmdType) []interface{} {
+func (l *Link) SQLParams(cmd sql_datastore.Cmd) []interface{} {
 	// TODO remove the need for these
 	if l.Src == nil {
 		l.Src = &Url{}
@@ -131,7 +132,7 @@ func (l *Link) SQLParams(cmd sqlutil.CmdType) []interface{} {
 	}
 
 	switch cmd {
-	case sqlutil.CmdSelectOne, sqlutil.CmdExistsOne, sqlutil.CmdDeleteOne:
+	case sql_datastore.CmdSelectOne, sql_datastore.CmdExistsOne, sql_datastore.CmdDeleteOne:
 		return []interface{}{
 			l.Src.Url,
 			l.Dst.Url,

--- a/link.go
+++ b/link.go
@@ -1,9 +1,14 @@
 package archive
 
 import (
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"github.com/archivers-space/sqlutil"
+	"github.com/ipfs/go-datastore"
+	"github.com/multiformats/go-multihash"
 
 	"time"
 )
@@ -12,6 +17,8 @@ import (
 // attribute points to the url that resolves to dst.
 // both src & dst must be stored as urls
 type Link struct {
+	// Calculated Hash for fixed ID purposes
+	Hash string
 	// created timestamp rounded to seconds in UTC
 	Created time.Time `json:"created"`
 	// updated timestamp rounded to seconds in UTC
@@ -22,44 +29,120 @@ type Link struct {
 	Dst *Url `json:"dst"`
 }
 
-func (l *Link) Read(db sqlutil.Queryable) error {
-	var row *sql.Row
-	if l.Src != nil && l.Dst != nil {
-		row = db.QueryRow(fmt.Sprintf("select %s from links where src = $1 and dst= $2", linkCols()), l.Src.Url, l.Dst.Url)
-	} else {
+func (l *Link) DatastoreType() string {
+	return "Link"
+}
+
+func (l *Link) GetId() string {
+	if l.Hash == "" {
+		l.calcHash()
+	}
+	return l.Hash
+}
+
+func (l *Link) Key() datastore.Key {
+	return datastore.NewKey(fmt.Sprintf("%s:%s", l.DatastoreType(), l.GetId()))
+}
+
+func (l *Link) Read(store datastore.Datastore) error {
+	if l.Src == nil || l.Dst == nil {
 		return ErrNotFound
 	}
-	return l.UnmarshalSQL(row)
+
+	li, err := store.Get(l.Key())
+	if err != nil {
+		return err
+	}
+
+	got, ok := li.(*Link)
+	if !ok {
+		return ErrInvalidResponse
+	}
+
+	*l = *got
+	return nil
 }
 
-func (l *Link) Insert(db sqlutil.Execable) error {
+func (l *Link) Insert(store datastore.Datastore) error {
 	l.Created = time.Now().In(time.UTC).Round(time.Second)
 	l.Updated = l.Created
-	_, err := db.Exec(fmt.Sprintf("insert into links (%s) values ($1, $2, $3, $4)", linkCols()), l.SQLArgs()...)
-	return err
+	return store.Put(l.Key(), l)
 }
 
-func (l *Link) Update(db sqlutil.Execable) error {
+func (l *Link) Update(store datastore.Datastore) error {
 	l.Updated = time.Now().Round(time.Second)
-	_, err := db.Exec("update links set created = $1, updated = $2 where src = $3 and dst = $4", l.SQLArgs()...)
-	return err
+	return store.Put(l.Key(), l)
 }
 
-func (l *Link) Delete(db sqlutil.Execable) error {
-	_, err := db.Exec("delete from links where src = $1 and dst = $2", l.Src.Url, l.Dst.Url)
-	return err
+func (l *Link) Delete(store datastore.Datastore) error {
+	return store.Delete(l.Key())
 }
 
-func linkCols() string {
-	return "created, updated, src, dst"
+func (l *Link) calcHash() {
+	h := sha256.New()
+	data, err := json.Marshal(struct {
+		Src string `json:"src"`
+		Dst string `json:"dst"`
+	}{
+		Src: l.Src.Url,
+		Dst: l.Dst.Url,
+	})
+	if err != nil {
+		return
+	}
+
+	h.Write(data)
+	mhBuf, err := multihash.EncodeName(h.Sum(nil), "sha2-256")
+	if err != nil {
+		return
+	}
+
+	l.Hash = hex.EncodeToString(mhBuf)
 }
 
-func (l *Link) SQLArgs() []interface{} {
-	return []interface{}{
-		l.Created.In(time.UTC),
-		l.Updated.In(time.UTC),
-		l.Src.Url,
-		l.Dst.Url,
+func (l Link) NewSQLModel(id string) sqlutil.Model {
+	return &Link{Hash: id}
+}
+
+func (l *Link) SQLQuery(cmd sqlutil.CmdType) string {
+	switch cmd {
+	case sqlutil.CmdCreateTable:
+		return qLinkCreateTable
+	case sqlutil.CmdExistsOne:
+		return qLinkExists
+	case sqlutil.CmdInsertOne:
+		return qLinkInsert
+	case sqlutil.CmdDeleteOne:
+		return qLinkDelete
+	case sqlutil.CmdUpdateOne:
+		return qLinkUpdate
+	default:
+		return ""
+	}
+}
+
+func (l *Link) SQLParams(cmd sqlutil.CmdType) []interface{} {
+	// TODO remove the need for these
+	if l.Src == nil {
+		l.Src = &Url{}
+	}
+	if l.Dst == nil {
+		l.Dst = &Url{}
+	}
+
+	switch cmd {
+	case sqlutil.CmdSelectOne, sqlutil.CmdExistsOne, sqlutil.CmdDeleteOne:
+		return []interface{}{
+			l.Src.Url,
+			l.Dst.Url,
+		}
+	default:
+		return []interface{}{
+			l.Created.In(time.UTC),
+			l.Updated.In(time.UTC),
+			l.Src.Url,
+			l.Dst.Url,
+		}
 	}
 }
 

--- a/link_test.go
+++ b/link_test.go
@@ -1,19 +1,21 @@
 package archive
 
 import (
+	"github.com/archivers-space/sql_datastore"
+	"github.com/ipfs/go-datastore"
 	"testing"
 )
 
 func TestLinkStorage(t *testing.T) {
-	defer resetTestData(appDB, "links")
+	store := datastore.NewMapDatastore()
 
 	l := &Link{Src: &Url{Url: "http://www.epa.gov"}, Dst: &Url{Url: "http://www.epa.gov"}}
-	if err := l.Insert(appDB); err != nil {
+	if err := l.Insert(store); err != nil {
 		t.Error(err.Error())
 		return
 	}
 
-	if err := l.Update(appDB); err != nil {
+	if err := l.Update(store); err != nil {
 		t.Error(err.Error())
 		return
 	}
@@ -22,7 +24,7 @@ func TestLinkStorage(t *testing.T) {
 		Src: &Url{Url: "http://www.epa.gov"},
 		Dst: &Url{Url: "http://www.epa.gov"},
 	}
-	if err := l2.Read(appDB); err != nil {
+	if err := l2.Read(store); err != nil {
 		t.Error(err.Error())
 		return
 	}
@@ -35,7 +37,50 @@ func TestLinkStorage(t *testing.T) {
 		t.Errorf("updated doesn't match: %s != %s", l2.Updated.String(), l.Updated.String())
 	}
 
-	if err := l.Delete(appDB); err != nil {
+	if err := l.Delete(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+}
+
+func TestLinkSQLStorage(t *testing.T) {
+	defer resetTestData(appDB, "links")
+
+	store := sql_datastore.NewDatastore(appDB)
+	if err := store.Register(&Link{}); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	l := &Link{Src: &Url{Url: "http://www.epa.gov"}, Dst: &Url{Url: "http://www.epa.gov"}}
+	if err := l.Insert(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	if err := l.Update(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	l2 := &Link{
+		Src: &Url{Url: "http://www.epa.gov"},
+		Dst: &Url{Url: "http://www.epa.gov"},
+	}
+	if err := l2.Read(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	if !l2.Created.Equal(l.Created) {
+		t.Errorf("created doesn't match: %s != %s", l2.Created.String(), l.Created.String())
+	}
+
+	if !l2.Updated.Equal(l.Updated) {
+		t.Errorf("updated doesn't match: %s != %s", l2.Updated.String(), l.Updated.String())
+	}
+
+	if err := l.Delete(store); err != nil {
 		t.Error(err.Error())
 		return
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -36,7 +36,17 @@ func setupTestDatabase() func() {
 		panic(err.Error())
 	}
 
-	if err := resetTestData(appDB, "primers", "sources", "urls", "links", "metadata", "snapshots", "collections", "archive_requests", "uncrawlables", "data_repos"); err != nil {
+	if err := resetTestData(appDB,
+		"primers",
+		"sources",
+		"urls",
+		"links",
+		"metadata",
+		"snapshots",
+		"collections",
+		"archive_requests",
+		"uncrawlables",
+		"data_repos"); err != nil {
 		panic(err.Error())
 	}
 

--- a/metadata.go
+++ b/metadata.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"github.com/archivers-space/sql_datastore"
 	"github.com/archivers-space/sqlutil"
 	"github.com/ipfs/go-datastore"
 	"github.com/multiformats/go-multihash"
@@ -179,8 +180,13 @@ func (m *Metadata) calcHash() error {
 }
 
 // WriteMetadata creates a snapshot record in the DB from a given Url struct
-func (m *Metadata) Write(db sqlutil.Execable) error {
+func (m *Metadata) Write(db *sql.DB) error {
 	// TODO - check for valid subject hash
+
+	store := sql_datastore.NewDatastore(db)
+	if err := store.Register(&Url{}); err != nil {
+		return err
+	}
 
 	m.Timestamp = time.Now().Round(time.Second)
 	if err := m.calcHash(); err != nil {
@@ -196,13 +202,13 @@ func (m *Metadata) Write(db sqlutil.Execable) error {
 	if str, ok := m.Meta["title"].(string); ok && str != "" {
 		go func() {
 			u := &Url{Hash: m.Subject}
-			if err := u.Read(db); err != nil {
+			if err := u.Read(store); err != nil {
 				return
 			}
 
 			// TODO - this is a straight set, should be derived from consensus calculation
 			u.Title = str
-			if err := u.Update(db); err != nil {
+			if err := u.Update(store); err != nil {
 				return
 			}
 		}()

--- a/metadata.go
+++ b/metadata.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/archivers-space/sqlutil"
+	"github.com/ipfs/go-datastore"
 	"github.com/multiformats/go-multihash"
 	"time"
 )
@@ -40,6 +41,21 @@ type Metadata struct {
 	Prev string `json:"prev"`
 	// Acutal metadata, a valid json Object
 	Meta map[string]interface{} `json:"meta"`
+}
+
+func (m Metadata) DatastoreType() string {
+	return "Metadata"
+}
+
+func (m Metadata) GetId() string {
+	if m.Hash == "" {
+		m.calcHash()
+	}
+	return m.Hash
+}
+
+func (m Metadata) Key() datastore.Key {
+	return datastore.NewKey(fmt.Sprintf("%s:%s", m.DatastoreType(), m.GetId()))
 }
 
 // String is metadata's abbreviated string representation

--- a/primer.go
+++ b/primer.go
@@ -182,34 +182,34 @@ func (p *Primer) Delete(store datastore.Datastore) error {
 	return store.Delete(p.Key())
 }
 
-func (p *Primer) NewSQLModel(id string) sqlutil.Model {
+func (p *Primer) NewSQLModel(id string) sql_datastore.Model {
 	return &Primer{Id: id}
 }
 
-func (p *Primer) SQLQuery(cmd sqlutil.CmdType) string {
+func (p *Primer) SQLQuery(cmd sql_datastore.Cmd) string {
 	switch cmd {
-	case sqlutil.CmdCreateTable:
+	case sql_datastore.CmdCreateTable:
 		return qPrimerCreateTable
-	case sqlutil.CmdExistsOne:
+	case sql_datastore.CmdExistsOne:
 		return qPrimerExists
-	case sqlutil.CmdSelectOne:
+	case sql_datastore.CmdSelectOne:
 		return qPrimerById
-	case sqlutil.CmdInsertOne:
+	case sql_datastore.CmdInsertOne:
 		return qPrimerInsert
-	case sqlutil.CmdUpdateOne:
+	case sql_datastore.CmdUpdateOne:
 		return qPrimerUpdate
-	case sqlutil.CmdDeleteOne:
+	case sql_datastore.CmdDeleteOne:
 		return qPrimerDelete
-	case sqlutil.CmdList:
+	case sql_datastore.CmdList:
 		return qPrimersList
 	default:
 		return ""
 	}
 }
 
-func (p *Primer) SQLParams(cmd sqlutil.CmdType) []interface{} {
+func (p *Primer) SQLParams(cmd sql_datastore.Cmd) []interface{} {
 	switch cmd {
-	case sqlutil.CmdSelectOne, sqlutil.CmdExistsOne, sqlutil.CmdDeleteOne:
+	case sql_datastore.CmdSelectOne, sql_datastore.CmdExistsOne, sql_datastore.CmdDeleteOne:
 		return []interface{}{p.Id}
 	default:
 		parentId := ""

--- a/primer.go
+++ b/primer.go
@@ -211,6 +211,8 @@ func (p *Primer) SQLParams(cmd sql_datastore.Cmd) []interface{} {
 	switch cmd {
 	case sql_datastore.CmdSelectOne, sql_datastore.CmdExistsOne, sql_datastore.CmdDeleteOne:
 		return []interface{}{p.Id}
+	case sql_datastore.CmdList:
+		return []interface{}{}
 	default:
 		parentId := ""
 		if p.Parent != nil {

--- a/primer.go
+++ b/primer.go
@@ -110,7 +110,7 @@ func (p *Primer) CalcStats(db *sql.DB) error {
 		p.Stats.ContentUrlCount += sp.Stats.ContentUrlCount
 	}
 
-	store := sql_datastore.Datastore{DB: db}
+	store := sql_datastore.NewDatastore(db)
 	if err := store.Register(&Primer{}); err != nil {
 		return err
 	}

--- a/primer_test.go
+++ b/primer_test.go
@@ -44,7 +44,7 @@ func TestPrimerStorage(t *testing.T) {
 func TestPrimerSQLStorage(t *testing.T) {
 	defer resetTestData(appDB, "primers", "sources")
 
-	store := sql_datastore.Datastore{DB: appDB}
+	store := sql_datastore.NewDatastore(appDB)
 	if err := store.Register(&Primer{}); err != nil {
 		t.Error(err.Error())
 		return
@@ -85,20 +85,20 @@ func TestPrimerSQLStorage(t *testing.T) {
 func TestPrimerReadSubprimers(t *testing.T) {
 	p := &Primer{Id: "5b1031f4-38a8-40b3-be91-c324bf686a87"}
 	if err := p.ReadSubPrimers(appDB); err != nil {
-		t.Fatal(err.Error())
+		t.Error(err.Error())
 	}
 }
 
 func TestPrimerReadSources(t *testing.T) {
 	p := &Primer{Id: "5b1031f4-38a8-40b3-be91-c324bf686a87"}
 	if err := p.ReadSources(appDB); err != nil {
-		t.Fatal(err.Error())
+		t.Error(err.Error())
 	}
 }
 
 func TestPrimerCalcStats(t *testing.T) {
 	p := &Primer{Id: "5b1031f4-38a8-40b3-be91-c324bf686a87"}
 	if err := p.CalcStats(appDB); err != nil {
-		t.Fatal(err.Error())
+		t.Error(err.Error())
 	}
 }

--- a/primer_test.go
+++ b/primer_test.go
@@ -1,26 +1,28 @@
 package archive
 
 import (
+	"github.com/archivers-space/sql_datastore"
+	"github.com/ipfs/go-datastore"
 	"testing"
 )
 
 func TestPrimerStorage(t *testing.T) {
-	defer resetTestData(appDB, "primers", "sources")
+	store := datastore.NewMapDatastore()
 
 	p := &Primer{Title: "Test Primer", Description: "test primer description!"}
-	if err := p.Save(appDB); err != nil {
+	if err := p.Save(store); err != nil {
 		t.Error(err.Error())
 		return
 	}
 
 	p.Description = "new description"
-	if err := p.Save(appDB); err != nil {
+	if err := p.Save(store); err != nil {
 		t.Error(err.Error())
 		return
 	}
 
 	p2 := &Primer{Id: p.Id}
-	if err := p2.Read(appDB); err != nil {
+	if err := p2.Read(store); err != nil {
 		t.Error(err.Error())
 		return
 	}
@@ -33,7 +35,48 @@ func TestPrimerStorage(t *testing.T) {
 		t.Errorf("updated doesn't match: %s != %s", p2.Updated.String(), p.Updated.String())
 	}
 
-	if err := p.Delete(appDB); err != nil {
+	if err := p.Delete(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+}
+
+func TestPrimerSQLStorage(t *testing.T) {
+	defer resetTestData(appDB, "primers", "sources")
+
+	store := sql_datastore.Datastore{DB: appDB}
+	if err := store.Register(&Primer{}); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	p := &Primer{Title: "Test Primer", Description: "test primer description!"}
+	if err := p.Save(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	p.Description = "new description"
+	if err := p.Save(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	p2 := &Primer{Id: p.Id}
+	if err := p2.Read(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	if !p2.Created.Equal(p.Created) {
+		t.Errorf("created doesn't match: %s != %s", p2.Created.String(), p.Created.String())
+	}
+
+	if !p2.Updated.Equal(p.Updated) {
+		t.Errorf("updated doesn't match: %s != %s", p2.Updated.String(), p.Updated.String())
+	}
+
+	if err := p.Delete(store); err != nil {
 		t.Error(err.Error())
 		return
 	}

--- a/primers_test.go
+++ b/primers_test.go
@@ -1,6 +1,7 @@
 package archive
 
 import (
+	"github.com/archivers-space/sql_datastore"
 	"testing"
 )
 
@@ -17,5 +18,29 @@ func TestCountPrimers(t *testing.T) {
 
 	if c != 6 {
 		t.Errorf("wrong number of primers, expected %d, got: %d", 6, c)
+	}
+}
+
+func TestListPrimers(t *testing.T) {
+	store := sql_datastore.NewDatastore(appDB)
+	if err := store.Register(&Primer{}); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	primers, err := ListPrimers(store, 20, 0)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if len(primers) != 6 {
+		t.Errorf("primers length mismatch")
+	}
+
+	primers, err = ListPrimers(store, 20, 10)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if len(primers) != 0 {
+		t.Errorf("primers length mismatch")
 	}
 }

--- a/queries.go
+++ b/queries.go
@@ -84,6 +84,50 @@ FROM data_repos
 ORDER BY created DESC 
 LIMIT $1 OFFSET $2;`
 
+// create links table
+const qLinkCreateTable = `
+CREATE TABLE IF NOT EXISTS links (
+  created          timestamp NOT NULL,
+  updated          timestamp NOT NULL,
+  src              text NOT NULL references urls(url) ON DELETE CASCADE,
+  dst              text NOT NULL references urls(url) ON DELETE CASCADE,
+  PRIMARY KEY      (src, dst)
+);`
+
+// check to see if a link exists
+const qLinkExists = `SELECT exists(select 1 from links where src = $1 and dst = $2)`
+
+// read a link
+const qLinkRead = `
+SELECT
+  created, updated, src, dst
+FROM links
+WHERE
+  src = $1 AND
+  dst = $2;`
+
+// insert a link
+const qLinkInsert = `
+INSERT INTO LINKS
+  (created, updated, src, dst)
+VALUES
+  ($1, $2, $3, $4);`
+
+// update a link
+const qLinkUpdate = `
+UPDATE links SET
+  created = $1, updated = $2
+WHERE
+  src = $3 AND
+  dst = $4`
+
+// delete a link
+const qLinkDelete = `
+DELETE FROM links
+WHERE
+  src = $1 AND
+  dst = $2;`
+
 // list latest metadata entries by reverse cronological order
 // paginated
 const qMetadataLatest = `
@@ -135,6 +179,10 @@ INSERT INTO metadata
   (hash, time_stamp, key_id, subject, prev, meta, deleted)
 VALUES 
   ($1, $2, $3, $4, $5, $6, false);`
+
+const qPrimerCreateTable = ``
+
+const qPrimerExists = `SELECT exists(SELECT 1 FROM primers WHERE id = $1)`
 
 // read a primer for a given Id
 const qPrimerById = `
@@ -215,6 +263,10 @@ where
   parent_id = ''
 order by created desc
 limit $1 offset $2;`
+
+const qSourceCreateTable = ``
+
+const qSourceExists = `SELECT exists(SELECT 1 FROM collections WHERE id = $1)`
 
 // select
 const qSourcesCount = `SELECT count(1) FROM sources;`
@@ -375,6 +427,29 @@ where
   url ilike $1 
 limit $2 offset $3;`
 
+const qUrlsCreateTable = `
+CREATE TABLE IF NOT EXISTS urls (
+  url              text PRIMARY KEY NOT NULL,
+  created          timestamp NOT NULL,
+  updated          timestamp NOT NULL,
+  last_head        timestamp,
+  last_get         timestamp,
+  status           integer NOT NULL default 0,
+  content_type     text NOT NULL default '',
+  content_sniff    text NOT NULL default '',
+  content_length   bigint NOT NULL default 0,
+  file_name        text NOT NULL default '',
+  title            text NOT NULL default '',
+  id               text NOT NULL default '',
+  headers_took     integer NOT NULL default 0,
+  download_took    integer NOT NULL default 0,
+  headers          json,
+  meta             json,
+  hash             text NOT NULL default ''
+);`
+
+const qUrlExists = `SELECT exists(SELECT 1 FROM urls WHERE id = $1)`
+
 const qUrlsList = `
 select
   url, created, updated, last_head, last_get, status, content_type, content_sniff,
@@ -521,6 +596,10 @@ from urls, links
 where 
   links.dst = $1 and 
   links.src = urls.url;`
+
+const qUncrawlableCreateTable = ``
+
+const qUncrawlableExists = `SELECT exists(SELECT 1 FROM uncrawlables WHERE id = $1)`
 
 const qUncrawlablesList = `
 select 

--- a/queries.go
+++ b/queries.go
@@ -705,6 +705,16 @@ select
 from uncrawlables 
 where url = $1;`
 
+const qUncrawlableById = `
+select 
+  id, url,created,updated,creator_key_id,
+  name,email,event_name,agency_name,
+  agency_id,subagency_id,org_id,suborg_id,subprimer_id,
+  ftp,database,interactive,many_files,
+  comments
+from uncrawlables 
+where id = $1;`
+
 const qUncrawlableDelete = `
 delete from uncrawlables 
 where url = $1;`

--- a/queries.go
+++ b/queries.go
@@ -63,6 +63,19 @@ UPDATE data_repos
 SET created=$2, updated=$3, title=$4, description=$5, url=$6
 WHERE id = $1;`
 
+const qDataRepoCreateTable = `
+CREATE TABLE IF NOT EXISTS data_repos (
+  id               UUID PRIMARY KEY NOT NULL,
+  created          timestamp NOT NULL default (now() at time zone 'utc'),
+  updated          timestamp NOT NULL default (now() at time zone 'utc'),
+  title            text NOT NULL default '',
+  description      text NOT NULL default '',
+  url              text NOT NULL default '',
+  deleted          boolean default false
+);`
+
+const qDataRepoExists = `SELECT exists(SELECT 1 FROM data_repos WHERE id = $1)`
+
 // read dataRepo info by ID
 const qDataRepoById = `
 SELECT 
@@ -127,6 +140,18 @@ DELETE FROM links
 WHERE
   src = $1 AND
   dst = $2;`
+
+const qMetadataCreateTable = `
+CREATE TABLE IF NOT EXISTS metadata (
+  hash             text NOT NULL default '',
+  time_stamp       timestamp NOT NULL,
+  key_id           text NOT NULL default '',
+  subject          text NOT NULL,
+  prev             text NOT NULL default '',
+  meta             json,
+  deleted          boolean default false
+);
+`
 
 // list latest metadata entries by reverse cronological order
 // paginated

--- a/queries.go
+++ b/queries.go
@@ -318,7 +318,8 @@ CREATE TABLE IF NOT EXISTS sources (
   deleted          boolean default false
 );`
 
-const qSourceExists = `SELECT exists(SELECT 1 FROM collections WHERE id = $1)`
+const qSourceExists = `SELECT exists(SELECT 1 FROM sources WHERE id = $1)`
+const qSourceExistsByUrl = `SELECT exists(SELECT 1 FROM sources WHERE url = $1)`
 
 // select
 const qSourcesCount = `SELECT count(1) FROM sources;`
@@ -574,6 +575,8 @@ from urls
 where 
   hash = $1;`
 
+const qUrlExistsByUrlString = `SELECT exists(SELECT 1 FROM urls WHERE url = $1)`
+
 const qUrlByUrlString = `
 select
   url, created, updated, last_head, last_get, status, content_type, content_sniff,
@@ -590,6 +593,8 @@ from urls
 where
   id = $1;`
 
+const qUrlExistsById = `SELECT exists(SELECT 1 FROM urls WHERE id = $1)`
+
 const qUrlByHash = `
 select
   url, created, updated, last_head, last_get, status, content_type, content_sniff,
@@ -597,6 +602,8 @@ select
 from urls 
 where
   hash = $1;`
+
+const qUrlExistsByHash = `SELECT exists(SELECT 1 FROM urls WHERE hash = $1)`
 
 const qUrlInsert = `
 insert into urls
@@ -664,6 +671,7 @@ where
 const qUncrawlableCreateTable = ``
 
 const qUncrawlableExists = `SELECT exists(SELECT 1 FROM uncrawlables WHERE id = $1)`
+const qUncrawlableExistsByUrl = `SELECT exists(SELECT 1 FROM uncrawlables WHERE url = $1)`
 
 const qUncrawlablesList = `
 select 

--- a/queries.go
+++ b/queries.go
@@ -668,7 +668,29 @@ where
   links.dst = $1 and 
   links.src = urls.url;`
 
-const qUncrawlableCreateTable = ``
+const qUncrawlableCreateTable = `
+CREATE TABLE IF NOT EXISTS uncrawlables (
+  id               text NOT NULL default '',
+  url              text PRIMARY KEY NOT NULL,
+  created          timestamp NOT NULL default (now() at time zone 'utc'),
+  updated          timestamp NOT NULL default (now() at time zone 'utc'),
+  creator_key_id   text NOT NULL default '',
+  name             text NOT NULL default '',
+  email            text NOT NULL default '',
+  event_name       text NOT NULL default '',
+  agency_name      text NOT NULL default '',
+  agency_id        text NOT NULL default '',
+  subagency_id     text NOT NULL default '',
+  org_id           text NOT NULL default '',
+  suborg_id        text NOT NULL default '',
+  subprimer_id     text NOT NULL default '',
+  ftp              boolean default false,
+  database         boolean default false,
+  interactive      boolean default false,
+  many_files       boolean default false,
+  comments         text NOT NULL default '',
+  deleted          boolean NOT NULL default false
+);`
 
 const qUncrawlableExists = `SELECT exists(SELECT 1 FROM uncrawlables WHERE id = $1)`
 const qUncrawlableExistsByUrl = `SELECT exists(SELECT 1 FROM uncrawlables WHERE url = $1)`
@@ -726,14 +748,3 @@ where id = $1;`
 const qUncrawlableDelete = `
 delete from uncrawlables 
 where url = $1;`
-
-const qUncrawlables = `
-select
-  url,created,updated,creator_key_id,
-  name,email,event_name,agency_name,
-  agency_id,subagency_id,org_id,suborg_id,subprimer_id,
-  ftp,database,interactive,many_files,
-  comments
-from uncrawlables 
-order by created desc 
-limit $1 offset $2;`

--- a/queries.go
+++ b/queries.go
@@ -1,5 +1,23 @@
 package archive
 
+// create collections table if it doesn't exist
+const qCollectionCreateTable = `
+CREATE TABLE IF NOT EXISTS collections (
+  id               UUID PRIMARY KEY,
+  created          timestamp NOT NULL,
+  updated          timestamp NOT NULL,
+  creator          text NOT NULL DEFAULT '',
+  title            text NOT NULL DEFAULT '',
+  url              text NOT NULL DEFAULT '',
+  schema           json,
+  contents         json
+);`
+
+// check for existence of a collection
+const qCollectionExists = `
+  SELECT exists(SELECT 1 FROM collections WHERE id = $1)
+`
+
 // insert a collection
 const qCollectionInsert = `
 INSERT INTO collections 

--- a/source.go
+++ b/source.go
@@ -281,6 +281,8 @@ func (s *Source) SQLQuery(cmd sql_datastore.Cmd) string {
 
 func (s *Source) SQLParams(cmd sql_datastore.Cmd) []interface{} {
 	switch cmd {
+	case sql_datastore.CmdList:
+		return []interface{}{}
 	case sql_datastore.CmdSelectOne, sql_datastore.CmdExistsOne:
 		if s.Id != "" {
 			return []interface{}{s.Id}
@@ -304,6 +306,10 @@ func (s *Source) SQLParams(cmd sql_datastore.Cmd) []interface{} {
 		statBytes, err := json.Marshal(s.Stats)
 		if err != nil {
 			panic(err)
+		}
+
+		if s.Primer == nil {
+			s.Primer = &Primer{}
 		}
 
 		return []interface{}{

--- a/source_test.go
+++ b/source_test.go
@@ -1,26 +1,29 @@
 package archive
 
 import (
+	"github.com/archivers-space/sql_datastore"
+	"github.com/ipfs/go-datastore"
 	"testing"
 )
 
 func TestSourceStorage(t *testing.T) {
-	defer resetTestData(appDB, "crawl_urls", "sources", "primers")
+
+	store := datastore.NewMapDatastore()
 
 	c := &Source{Url: "youtube.com", Primer: &Primer{Id: "5b1031f4-38a8-40b3-be91-c324bf686a87"}, Crawl: true}
-	if err := c.Save(appDB); err != nil {
+	if err := c.Save(store); err != nil {
 		t.Error(err.Error())
 		return
 	}
 
 	c.Crawl = false
-	if err := c.Save(appDB); err != nil {
+	if err := c.Save(store); err != nil {
 		t.Error(err.Error())
 		return
 	}
 
 	c2 := &Source{Url: "youtube.com"}
-	if err := c2.Read(appDB); err != nil {
+	if err := c2.Read(store); err != nil {
 		t.Error(err.Error())
 		return
 	}
@@ -37,7 +40,52 @@ func TestSourceStorage(t *testing.T) {
 		t.Errorf("updated doesn't match: %s != %s", c2.Updated.String(), c.Updated.String())
 	}
 
-	if err := c.Delete(appDB); err != nil {
+	if err := c.Delete(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+}
+
+func TestSourceSQLStorage(t *testing.T) {
+	defer resetTestData(appDB, "crawl_urls", "sources", "primers")
+
+	store := sql_datastore.Datastore{DB: appDB}
+	if err := store.Register(&Source{}); err != nil {
+		t.Error(err)
+		return
+	}
+
+	c := &Source{Url: "youtube.com", Primer: &Primer{Id: "5b1031f4-38a8-40b3-be91-c324bf686a87"}, Crawl: true}
+	if err := c.Save(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	c.Crawl = false
+	if err := c.Save(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	c2 := &Source{Url: "youtube.com"}
+	if err := c2.Read(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	if c2.Crawl != c.Crawl {
+		t.Errorf("crawl doesn't match: %t != %t", c2.Crawl, c.Crawl)
+	}
+
+	if !c2.Created.Equal(c.Created) {
+		t.Errorf("created doesn't match: %s != %s", c2.Created.String(), c.Created.String())
+	}
+
+	if !c2.Updated.Equal(c.Updated) {
+		t.Errorf("updated doesn't match: %s != %s", c2.Updated.String(), c.Updated.String())
+	}
+
+	if err := c.Delete(store); err != nil {
 		t.Error(err.Error())
 		return
 	}
@@ -49,8 +97,14 @@ func TestSourceUndescribedContent(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
+	store := sql_datastore.Datastore{DB: appDB}
+	if err := store.Register(&Source{}); err != nil {
+		t.Error(err)
+		return
+	}
+
 	c := &Source{Url: "www.census.gov"}
-	if err := c.Read(appDB); err != nil {
+	if err := c.Read(store); err != nil {
 		t.Error(err.Error())
 		return
 	}
@@ -74,8 +128,14 @@ func TestSourceDescribedContent(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
+	store := sql_datastore.Datastore{DB: appDB}
+	if err := store.Register(&Source{}); err != nil {
+		t.Error(err)
+		return
+	}
+
 	c := &Source{Url: "www.census.gov"}
-	if err := c.Read(appDB); err != nil {
+	if err := c.Read(store); err != nil {
 		t.Error(err.Error())
 		return
 	}

--- a/source_test.go
+++ b/source_test.go
@@ -22,7 +22,7 @@ func TestSourceStorage(t *testing.T) {
 		return
 	}
 
-	c2 := &Source{Url: "youtube.com"}
+	c2 := &Source{Id: c.Id}
 	if err := c2.Read(store); err != nil {
 		t.Error(err.Error())
 		return
@@ -49,7 +49,7 @@ func TestSourceStorage(t *testing.T) {
 func TestSourceSQLStorage(t *testing.T) {
 	defer resetTestData(appDB, "crawl_urls", "sources", "primers")
 
-	store := sql_datastore.Datastore{DB: appDB}
+	store := sql_datastore.NewDatastore(appDB)
 	if err := store.Register(&Source{}); err != nil {
 		t.Error(err)
 		return
@@ -97,7 +97,7 @@ func TestSourceUndescribedContent(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	store := sql_datastore.Datastore{DB: appDB}
+	store := sql_datastore.NewDatastore(appDB)
 	if err := store.Register(&Source{}); err != nil {
 		t.Error(err)
 		return
@@ -128,7 +128,7 @@ func TestSourceDescribedContent(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	store := sql_datastore.Datastore{DB: appDB}
+	store := sql_datastore.NewDatastore(appDB)
 	if err := store.Register(&Source{}); err != nil {
 		t.Error(err)
 		return

--- a/sources_test.go
+++ b/sources_test.go
@@ -1,6 +1,7 @@
 package archive
 
 import (
+	"github.com/archivers-space/sql_datastore"
 	"testing"
 )
 
@@ -21,13 +22,26 @@ func TestCountSources(t *testing.T) {
 }
 
 func TestListSources(t *testing.T) {
-	s, err := ListSources(appDB, 100, 0)
-	if err != nil {
-		t.Fatal(err.Error())
+	store := sql_datastore.NewDatastore(appDB)
+	if err := store.Register(&Source{}); err != nil {
+		t.Error(err.Error())
+		return
 	}
 
-	if len(s) != 4 {
-		t.Errorf("wrong number of sources, expected %d, got: %d", 4, len(s))
+	sources, err := ListSources(store, 20, 0)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if len(sources) != 4 {
+		t.Errorf("sources length mismatch")
+	}
+
+	sources, err = ListSources(store, 20, 10)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if len(sources) != 0 {
+		t.Errorf("sources length mismatch")
 	}
 }
 

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -2,7 +2,7 @@
 DROP TABLE IF EXISTS urls, links, primers, sources, subprimers, alerts, context, metadata, supress_alerts, snapshots, collections, archive_requests, uncrawlables, data_repos;
 
 -- name: create-primers
-CREATE TABLE primers (
+CREATE TABLE IF NOT EXISTS primers (
   id               UUID PRIMARY KEY NOT NULL,
   created          timestamp NOT NULL default (now() at time zone 'utc'),
   updated          timestamp NOT NULL default (now() at time zone 'utc'),
@@ -16,7 +16,7 @@ CREATE TABLE primers (
 );
 
 -- name: create-sources
-CREATE TABLE sources (
+CREATE TABLE IF NOT EXISTS sources (
   id               UUID PRIMARY KEY NOT NULL,
   created          timestamp NOT NULL default (now() at time zone 'utc'),
   updated          timestamp NOT NULL default (now() at time zone 'utc'),
@@ -33,7 +33,7 @@ CREATE TABLE sources (
 );
 
 -- name: create-urls
-CREATE TABLE urls (
+CREATE TABLE IF NOT EXISTS urls (
   url              text PRIMARY KEY NOT NULL,
   created          timestamp NOT NULL,
   updated          timestamp NOT NULL,
@@ -54,7 +54,7 @@ CREATE TABLE urls (
 );
 
 -- name: create-links
-CREATE TABLE links (
+CREATE TABLE IF NOT EXISTS links (
   created          timestamp NOT NULL,
   updated          timestamp NOT NULL,
   src              text NOT NULL references urls(url) ON DELETE CASCADE,
@@ -63,7 +63,7 @@ CREATE TABLE links (
 );
 
 -- name: create-metadata
-CREATE TABLE metadata (
+CREATE TABLE IF NOT EXISTS metadata (
   hash             text NOT NULL default '',
   time_stamp       timestamp NOT NULL,
   key_id           text NOT NULL default '',
@@ -74,7 +74,7 @@ CREATE TABLE metadata (
 );
 
 -- name: create-snapshots
-CREATE TABLE snapshots (
+CREATE TABLE IF NOT EXISTS snapshots (
   url              text NOT NULL references urls(url) ON DELETE CASCADE,
   created          timestamp NOT NULL,
   status           integer NOT NULL DEFAULT 0,
@@ -84,7 +84,7 @@ CREATE TABLE snapshots (
 );
 
 -- name: create-collections
-CREATE TABLE collections (
+CREATE TABLE IF NOT EXISTS collections (
   id               UUID PRIMARY KEY,
   created          timestamp NOT NULL,
   updated          timestamp NOT NULL,
@@ -96,14 +96,14 @@ CREATE TABLE collections (
 );
 
 -- name: create-collection_contents
-CREATE TABLE collection_contents (
+CREATE TABLE IF NOT EXISTS collection_contents (
 	collection_id    UUID NOT NULL,
 	hash             text NOT NULL default '',
 	PRIMARY KEY      (collection_id, hash)
 );
 
 -- name: create-uncrawlables
-CREATE TABLE uncrawlables (
+CREATE TABLE IF NOT EXISTS uncrawlables (
   id               text NOT NULL default '',
   url              text PRIMARY KEY NOT NULL,
   created          timestamp NOT NULL default (now() at time zone 'utc'),
@@ -127,7 +127,7 @@ CREATE TABLE uncrawlables (
 );
 
 -- name: create-archive_requests
-CREATE TABLE archive_requests (
+CREATE TABLE IF NOT EXISTS archive_requests (
   id               serial primary key,
   created          timestamp NOT NULL default (now() at time zone 'utc'),
   url              text NOT NULL,
@@ -135,7 +135,7 @@ CREATE TABLE archive_requests (
 );
 
 -- name: create-data_repos
-CREATE TABLE data_repos (
+CREATE TABLE IF NOT EXISTS data_repos (
   id               UUID PRIMARY KEY NOT NULL,
   created          timestamp NOT NULL default (now() at time zone 'utc'),
   updated          timestamp NOT NULL default (now() at time zone 'utc'),
@@ -145,7 +145,7 @@ CREATE TABLE data_repos (
   deleted          boolean default false
 );
 
--- CREATE TABLE alerts (
+-- CREATE TABLE IF NOT EXISTS alerts (
 --   id   UUID UNIQUE NOT NULL,
 --   created   integer NOT NULL,
 --   updated   integer NOT NULL,

--- a/uncrawlable.go
+++ b/uncrawlable.go
@@ -154,7 +154,7 @@ func (u *Uncrawlable) SQLQuery(cmd sql_datastore.Cmd) string {
 	case sql_datastore.CmdDeleteOne:
 		return qUncrawlableDelete
 	case sql_datastore.CmdList:
-		return qUncrawlables
+		return qUncrawlablesList
 	default:
 		return ""
 	}
@@ -163,6 +163,8 @@ func (u *Uncrawlable) SQLQuery(cmd sql_datastore.Cmd) string {
 // SQLParams formats a uncrawlable struct for inserting / updating into postgres
 func (u *Uncrawlable) SQLParams(cmd sql_datastore.Cmd) []interface{} {
 	switch cmd {
+	case sql_datastore.CmdList:
+		return []interface{}{}
 	case sql_datastore.CmdSelectOne, sql_datastore.CmdExistsOne, sql_datastore.CmdDeleteOne:
 		return []interface{}{u.Id}
 	default:

--- a/uncrawlable.go
+++ b/uncrawlable.go
@@ -70,43 +70,65 @@ func (u Uncrawlable) Key() datastore.Key {
 }
 
 // Read uncrawlable from db
-func (c *Uncrawlable) Read(db sqlutil.Queryable) error {
-	if c.Url != "" {
-		row := db.QueryRow(qUncrawlableByUrl, c.Url)
-		return c.UnmarshalSQL(row)
+func (u *Uncrawlable) Read(store datastore.Datastore) error {
+	// return store.Delete(u.Key())
+	if u.Id != "" {
+		ui, err := store.Get(u.Key())
+		if err != nil {
+			return err
+		}
+
+		got, ok := ui.(*Uncrawlable)
+		if !ok {
+			return ErrInvalidResponse
+		}
+		*u = *got
+		return nil
+	} else {
+		// TODO - figure out a way to query stores by url...
+		if sqlstore, ok := store.(*sql_datastore.Datastore); ok {
+			if u.Url != "" {
+				row := sqlstore.DB.QueryRow(qUncrawlableByUrl, u.Url)
+				return u.UnmarshalSQL(row)
+			}
+		}
 	}
+
 	return ErrNotFound
 }
 
 // Save a uncrawlable
-func (c *Uncrawlable) Save(db sqlutil.Execable) error {
-	prev := &Uncrawlable{Url: c.Url}
-	if err := prev.Read(db); err != nil {
-		if err == ErrNotFound {
-			c.Id = uuid.New()
-			c.Created = time.Now().Round(time.Second)
-			c.Updated = c.Created
-			_, err := db.Exec(qUncrawlableInsert, c.SQLArgs()...)
-			return err
-		} else {
+func (u *Uncrawlable) Save(store datastore.Datastore) (err error) {
+	var exists bool
+
+	if u.Id != "" {
+		exists, err = store.Has(u.Key())
+		if err != nil {
 			return err
 		}
-	} else {
-		c.Updated = time.Now().Round(time.Second)
-		_, err := db.Exec(qUncrawlableUpdate, c.SQLArgs()...)
-		return err
 	}
-	return nil
+
+	if !exists {
+		u.Id = uuid.New()
+		u.Created = time.Now().Round(time.Second)
+		u.Updated = u.Created
+	} else {
+		u.Updated = time.Now().Round(time.Second)
+	}
+
+	return store.Put(u.Key(), u)
 }
 
 // Delete a uncrawlable, should only do for erronious additions
-func (c *Uncrawlable) Delete(db sqlutil.Execable) error {
-	_, err := db.Exec(qUncrawlableDelete, c.Url)
-	return err
+func (u *Uncrawlable) Delete(store datastore.Datastore) error {
+	return store.Delete(u.Key())
 }
 
-func (u Uncrawlable) NewSQLModel(id string) sql_datastore.Model {
-	return &Uncrawlable{Id: id}
+func (u *Uncrawlable) NewSQLModel(id string) sql_datastore.Model {
+	return &Uncrawlable{
+		Id:  id,
+		Url: u.Url,
+	}
 }
 
 func (u *Uncrawlable) SQLQuery(cmd sql_datastore.Cmd) string {
@@ -114,7 +136,11 @@ func (u *Uncrawlable) SQLQuery(cmd sql_datastore.Cmd) string {
 	case sql_datastore.CmdCreateTable:
 		return qUncrawlableCreateTable
 	case sql_datastore.CmdExistsOne:
-		return qUncrawlableExists
+		if u.Id == "" {
+			return qUncrawlableExistsByUrl
+		} else {
+			return qUncrawlableExists
+		}
 	case sql_datastore.CmdSelectOne:
 		if u.Id == "" {
 			return qUncrawlableByUrl
@@ -131,6 +157,36 @@ func (u *Uncrawlable) SQLQuery(cmd sql_datastore.Cmd) string {
 		return qUncrawlables
 	default:
 		return ""
+	}
+}
+
+// SQLParams formats a uncrawlable struct for inserting / updating into postgres
+func (u *Uncrawlable) SQLParams(cmd sql_datastore.Cmd) []interface{} {
+	switch cmd {
+	case sql_datastore.CmdSelectOne, sql_datastore.CmdExistsOne, sql_datastore.CmdDeleteOne:
+		return []interface{}{u.Id}
+	default:
+		return []interface{}{
+			u.Id,
+			u.Url,
+			u.Created.In(time.UTC),
+			u.Updated.In(time.UTC),
+			u.Creator,
+			u.Name,
+			u.Email,
+			u.EventName,
+			u.Agency,
+			u.AgencyId,
+			u.SubagencyId,
+			u.OrgId,
+			u.SuborgId,
+			u.SubprimerId,
+			u.Ftp,
+			u.Database,
+			u.Interactive,
+			u.ManyFiles,
+			u.Comments,
+		}
 	}
 }
 
@@ -180,33 +236,4 @@ func (u *Uncrawlable) UnmarshalSQL(row sqlutil.Scannable) (err error) {
 	}
 
 	return nil
-}
-
-// SQLArgs formats a uncrawlable struct for inserting / updating into postgres
-func (u *Uncrawlable) SQLParams(cmd sql_datastore.Cmd) []interface{} {
-	switch cmd {
-
-	default:
-		return []interface{}{
-			u.Id,
-			u.Url,
-			u.Created.In(time.UTC),
-			u.Updated.In(time.UTC),
-			u.Creator,
-			u.Name,
-			u.Email,
-			u.EventName,
-			u.Agency,
-			u.AgencyId,
-			u.SubagencyId,
-			u.OrgId,
-			u.SuborgId,
-			u.SubprimerId,
-			u.Ftp,
-			u.Database,
-			u.Interactive,
-			u.ManyFiles,
-			u.Comments,
-		}
-	}
 }

--- a/uncrawlable_test.go
+++ b/uncrawlable_test.go
@@ -1,26 +1,29 @@
 package archive
 
 import (
+	"github.com/archivers-space/sql_datastore"
+	"github.com/ipfs/go-datastore"
 	"testing"
 )
 
 func TestUncrawlableStorage(t *testing.T) {
-	defer resetTestData(appDB, "uncrawlables")
+
+	store := datastore.NewMapDatastore()
 
 	p := &Uncrawlable{Url: "http://www.epa.gov"}
-	if err := p.Save(appDB); err != nil {
+	if err := p.Save(store); err != nil {
 		t.Error(err.Error())
 		return
 	}
 
 	p.Comments = "new comment"
-	if err := p.Save(appDB); err != nil {
+	if err := p.Save(store); err != nil {
 		t.Error(err.Error())
 		return
 	}
 
-	p2 := &Uncrawlable{Url: "http://www.epa.gov"}
-	if err := p2.Read(appDB); err != nil {
+	p2 := &Uncrawlable{Id: p.Id}
+	if err := p2.Read(store); err != nil {
 		t.Error(err.Error())
 		return
 	}
@@ -33,7 +36,48 @@ func TestUncrawlableStorage(t *testing.T) {
 		t.Errorf("updated doesn't match: %s != %s", p2.Updated.String(), p.Updated.String())
 	}
 
-	if err := p.Delete(appDB); err != nil {
+	if err := p.Delete(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+}
+
+func TestUncrawlableSQLStorage(t *testing.T) {
+	defer resetTestData(appDB, "uncrawlables")
+
+	store := sql_datastore.NewDatastore(appDB)
+	if err := store.Register(&Uncrawlable{}); err != nil {
+		t.Error(err)
+		return
+	}
+
+	p := &Uncrawlable{Url: "http://www.epa.gov"}
+	if err := p.Save(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	p.Comments = "new comment"
+	if err := p.Save(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	p2 := &Uncrawlable{Url: "http://www.epa.gov"}
+	if err := p2.Read(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	if !p2.Created.Equal(p.Created) {
+		t.Errorf("created doesn't match: %s != %s", p2.Created.String(), p.Created.String())
+	}
+
+	if !p2.Updated.Equal(p.Updated) {
+		t.Errorf("updated doesn't match: %s != %s", p2.Updated.String(), p.Updated.String())
+	}
+
+	if err := p.Delete(store); err != nil {
 		t.Error(err.Error())
 		return
 	}

--- a/uncrawlables.go
+++ b/uncrawlables.go
@@ -1,30 +1,55 @@
 package archive
 
 import (
-	"database/sql"
-	"github.com/archivers-space/sqlutil"
+
+	// "database/sql"
+	// "github.com/archivers-space/sqlutil"
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/query"
 )
 
-func ListUncrawlables(db sqlutil.Queryable, limit, offset int) ([]*Uncrawlable, error) {
-	rows, err := db.Query(qUncrawlablesList, limit, offset)
+func ListUncrawlables(store datastore.Datastore, limit, offset int) ([]*Uncrawlable, error) {
+	q := query.Query{
+		Prefix: Uncrawlable{}.DatastoreType(),
+		Limit:  limit,
+		Offset: offset,
+	}
+
+	res, err := store.Query(q)
 	if err != nil {
 		return nil, err
 	}
-	return UnmarshalBoundedUncrawlables(rows, limit)
-}
 
-func UnmarshalBoundedUncrawlables(rows *sql.Rows, limit int) ([]*Uncrawlable, error) {
-	defer rows.Close()
-	subprimers := make([]*Uncrawlable, limit)
+	uncrawlables := make([]*Uncrawlable, limit)
 	i := 0
-	for rows.Next() {
-		u := &Uncrawlable{}
-		if err := u.UnmarshalSQL(rows); err != nil {
+	for r := range res.Next() {
+		if r.Error != nil {
 			return nil, err
 		}
-		subprimers[i] = u
+		c, ok := r.Value.(*Uncrawlable)
+		if !ok {
+			return nil, ErrInvalidResponse
+		}
+
+		uncrawlables[i] = c
 		i++
 	}
 
-	return subprimers[:i], nil
+	return uncrawlables[:i], nil
 }
+
+// func UnmarshalBoundedUncrawlables(rows *sql.Rows, limit int) ([]*Uncrawlable, error) {
+// 	defer rows.Close()
+// 	subuncrawlables := make([]*Uncrawlable, limit)
+// 	i := 0
+// 	for rows.Next() {
+// 		u := &Uncrawlable{}
+// 		if err := u.UnmarshalSQL(rows); err != nil {
+// 			return nil, err
+// 		}
+// 		subuncrawlables[i] = u
+// 		i++
+// 	}
+
+// 	return subuncrawlables[:i], nil
+// }

--- a/uncrawlables_test.go
+++ b/uncrawlables_test.go
@@ -1,0 +1,33 @@
+package archive
+
+import (
+	"github.com/archivers-space/sql_datastore"
+	"testing"
+)
+
+func TestListUncrawlables(t *testing.T) {
+	resetTestData(appDB, "uncrawlables")
+
+	store := sql_datastore.NewDatastore(appDB)
+	if err := store.Register(&Uncrawlable{}); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	uncrawlables, err := ListUncrawlables(store, 20, 0)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if len(uncrawlables) != 1 {
+		t.Errorf("uncrawlables length mismatch")
+	}
+
+	uncrawlables, err = ListUncrawlables(store, 20, 10)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if len(uncrawlables) != 0 {
+		t.Errorf("uncrawlables length mismatch")
+	}
+}

--- a/url.go
+++ b/url.go
@@ -541,6 +541,8 @@ func (u *Url) SQLQuery(cmd sql_datastore.Cmd) string {
 // SQLArgs formats a url struct for inserting / updating into postgres
 func (u *Url) SQLParams(cmd sql_datastore.Cmd) []interface{} {
 	switch cmd {
+	case sql_datastore.CmdList:
+		return []interface{}{}
 	case sql_datastore.CmdSelectOne, sql_datastore.CmdExistsOne:
 		// fmt.Println(u)
 		if u.Id != "" {
@@ -550,8 +552,6 @@ func (u *Url) SQLParams(cmd sql_datastore.Cmd) []interface{} {
 		} else {
 			return []interface{}{u.Url}
 		}
-	case sql_datastore.CmdList:
-		return []interface{}{}
 	case sql_datastore.CmdDeleteOne:
 		return []interface{}{u.Url}
 	default:

--- a/url.go
+++ b/url.go
@@ -452,46 +452,6 @@ func (u *Url) HeadersMap() (headers map[string]string) {
 	return
 }
 
-// Metadata collects up all metadata as
-// func (u *Url) Metadata(db sqlutil.Queryable) (*Meta, error) {
-// 	contexts, err := u.ReadContexts(db)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-
-// 	ibl, err := u.InboundLinks(db)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-
-// 	obl, err := u.OutboundLinks(db)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-
-// 	var sha string
-// 	if len(u.Hash) > 4 {
-// 		sha = u.Hash[3:]
-// 	}
-
-// 	return &Meta{
-// 		Url:           u.Url,
-// 		Date:          u.LastGet,
-// 		HeadersTook:   u.HeadersTook,
-// 		Id:            u.Id,
-// 		Status:        u.Status,
-// 		ContentSniff:  u.ContentSniff,
-// 		RawHeaders:    u.Headers,
-// 		Headers:       u.HeadersMap(),
-// 		DownloadTook:  u.DownloadTook,
-// 		Sha256:        sha,
-// 		Multihash:     u.Hash,
-// 		Contexts:      contexts,
-// 		InboundLinks:  ibl,
-// 		OutboundLinks: obl,
-// 	}, nil
-// }
-
 // UnmarshalSQL reads an sql response into the url receiver
 // it expects the request to have used urlCols() for selection
 func (u *Url) UnmarshalSQL(row sqlutil.Scannable) (err error) {

--- a/url.go
+++ b/url.go
@@ -8,6 +8,7 @@ import (
 	"github.com/archivers-space/ffi"
 	"github.com/archivers-space/sql_datastore"
 	"github.com/archivers-space/sqlutil"
+	"github.com/ipfs/go-datastore"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -94,6 +95,18 @@ type Url struct {
 	Uncrawlable *Uncrawlable `json:"uncrawlable,omitempty"`
 }
 
+func (u Url) DatastoreType() string {
+	return "Url"
+}
+
+func (u Url) GetId() string {
+	return u.Id
+}
+
+func (u Url) Key() datastore.Key {
+	return datastore.NewKey(fmt.Sprintf("%s:%s", u.DatastoreType(), u.GetId()))
+}
+
 // ParsedUrl is a convenience wrapper around url.Parse
 func (u *Url) ParsedUrl() (*url.URL, error) {
 	return url.Parse(u.Url)
@@ -133,6 +146,11 @@ func (u *Url) HandleGetResponse(db *sql.DB, res *http.Response, done func(err er
 	if err != nil {
 		done(err)
 		return
+	}
+
+	store := sql_datastore.NewDatastore(db)
+	if err := store.Register(&Url{}); err != nil {
+		return nil, err
 	}
 
 	// universally recorded responses:
@@ -194,7 +212,7 @@ func (u *Url) HandleGetResponse(db *sql.DB, res *http.Response, done func(err er
 		}
 	}
 
-	err = u.Update(db)
+	err = u.Update(store)
 	if err != nil {
 		return
 	}
@@ -339,29 +357,53 @@ func (u *Url) File() (*File, error) {
 }
 
 // Read url from db
-func (u *Url) Read(db sqlutil.Queryable) error {
-	var row *sql.Row
+func (u *Url) Read(store datastore.Datastore) error {
 	if u.Id != "" {
-		row = db.QueryRow(qUrlById, u.Id)
-	} else if u.Url != "" {
-		row = db.QueryRow(qUrlByUrlString, u.Url)
+		ci, err := store.Get(u.Key())
+		if err != nil {
+			return err
+		}
+
+		got, ok := ci.(*Url)
+		if !ok {
+			return ErrInvalidResponse
+		}
+		*u = *got
+		return nil
 	} else {
-		return ErrNotFound
+		// TODO - figure out a way to query stores by url...
+		if sqlstore, ok := store.(*sql_datastore.Datastore); ok {
+			if u.Url != "" {
+				row := sqlstore.DB.QueryRow(qUrlByUrlString, u.Url)
+				return u.UnmarshalSQL(row)
+			} else if u.Hash != "" {
+				row := sqlstore.DB.QueryRow(qUrlByHash, u.Hash)
+				return u.UnmarshalSQL(row)
+			}
+		}
 	}
-	return u.UnmarshalSQL(row)
+	return ErrNotFound
 }
 
 // Insert (create)
-func (u *Url) Insert(db sqlutil.Execable) error {
+func (u *Url) Insert(store datastore.Datastore) error {
 	u.Created = time.Now().Round(time.Second)
 	u.Updated = u.Created
 	u.Id = uuid.New()
-	_, err := db.Exec(qUrlInsert, u.SQLArgs()...)
-	return err
+	return store.Put(u.Key(), u)
 }
 
 // Update url db entry
-func (u *Url) Update(db sqlutil.Execable) error {
+func (u *Url) Update(store datastore.Datastore) error {
+	// Need to fetch ID
+	if u.Url != "" && u.Id == "" {
+		prev := &Url{Url: u.Url}
+		if err := prev.Read(store); err != ErrNotFound {
+			return err
+		}
+		u.Id = prev.Id
+	}
+
 	u.Updated = time.Now().Round(time.Second)
 	if u.ContentLength < -1 {
 		u.ContentLength = -1
@@ -369,14 +411,12 @@ func (u *Url) Update(db sqlutil.Execable) error {
 	if u.Status < -1 {
 		u.Status = -1
 	}
-	_, err := db.Exec(qUrlUpdate, u.SQLArgs()...)
-	return err
+	return store.Put(u.Key(), u)
 }
 
 // Delete a url, should only do for erronious additions
-func (u *Url) Delete(db sqlutil.Execable) error {
-	_, err := db.Exec(qUrlDelete, u.Url)
-	return err
+func (u *Url) Delete(store datastore.Datastore) error {
+	return store.Delete(u.Key())
 }
 
 // ExtractDocLinks extracts & stores a page's linked documents
@@ -385,6 +425,11 @@ func (u *Url) Delete(db sqlutil.Execable) error {
 func (u *Url) ExtractDocLinks(db *sql.DB, doc *goquery.Document) ([]*Link, error) {
 	pUrl, err := u.ParsedUrl()
 	if err != nil {
+		return nil, err
+	}
+
+	store := sql_datastore.NewDatastore(db)
+	if err := store.Register(&Link{}); err != nil {
 		return nil, err
 	}
 
@@ -401,9 +446,9 @@ func (u *Url) ExtractDocLinks(db *sql.DB, doc *goquery.Document) ([]*Link, error
 
 		dst := &Url{Url: address.String()}
 		// Check to see if url exists, creating if not
-		if err = dst.Read(db); err != nil {
+		if err = dst.Read(store); err != nil {
 			if err == ErrNotFound {
-				if err = dst.Insert(db); err != nil {
+				if err = dst.Insert(store); err != nil {
 					return
 				}
 			} else {
@@ -450,6 +495,107 @@ func (u *Url) HeadersMap() (headers map[string]string) {
 		}
 	}
 	return
+}
+
+func (u *Url) NewSQLModel(id string) sql_datastore.Model {
+	return &Url{
+		Id:   id,
+		Url:  u.Url,
+		Hash: u.Hash,
+	}
+}
+
+func (u *Url) SQLQuery(cmd sql_datastore.Cmd) string {
+	switch cmd {
+	case sql_datastore.CmdCreateTable:
+		return qUrlsCreateTable
+	case sql_datastore.CmdSelectOne:
+		if u.Id != "" {
+			return qUrlById
+		} else if u.Hash != "" {
+			return qUrlByHash
+		} else {
+			return qUrlByUrlString
+		}
+	case sql_datastore.CmdExistsOne:
+		if u.Id != "" {
+			return qUrlExistsById
+		} else if u.Hash != "" {
+			return qUrlExistsByHash
+		} else {
+			return qUrlExistsByUrlString
+		}
+	case sql_datastore.CmdInsertOne:
+		return qUrlInsert
+	case sql_datastore.CmdUpdateOne:
+		return qUrlUpdate
+	case sql_datastore.CmdDeleteOne:
+		return qUrlDelete
+	case sql_datastore.CmdList:
+		return qUrlsList
+	default:
+		return ""
+	}
+}
+
+// SQLArgs formats a url struct for inserting / updating into postgres
+func (u *Url) SQLParams(cmd sql_datastore.Cmd) []interface{} {
+	switch cmd {
+	case sql_datastore.CmdSelectOne, sql_datastore.CmdExistsOne:
+		// fmt.Println(u)
+		if u.Id != "" {
+			return []interface{}{u.Id}
+		} else if u.Hash != "" {
+			return []interface{}{u.Hash}
+		} else {
+			return []interface{}{u.Url}
+		}
+	case sql_datastore.CmdList:
+		return []interface{}{}
+	case sql_datastore.CmdDeleteOne:
+		return []interface{}{u.Url}
+	default:
+		headerBytes, err := json.Marshal(u.Headers)
+		if err != nil {
+			panic(err)
+		}
+		metaBytes, err := json.Marshal(u.Meta)
+		if err != nil {
+			panic(err)
+		}
+
+		lastGet := u.LastGet
+		if lastGet != nil {
+			utc := lastGet.In(time.UTC)
+			lastGet = &utc
+		}
+
+		lastHead := u.LastHead
+		if lastHead != nil {
+			utc := lastHead.In(time.UTC)
+			lastHead = &utc
+		}
+
+		return []interface{}{
+			u.Url,
+			u.Created.In(time.UTC),
+			u.Updated.In(time.UTC),
+			lastHead,
+			lastGet,
+			u.Status,
+			u.ContentType,
+			u.ContentSniff,
+			u.ContentLength,
+			u.FileName,
+			u.Title,
+			u.Id,
+			u.HeadersTook,
+			u.DownloadTook,
+			headerBytes,
+			metaBytes,
+			u.Hash,
+		}
+	}
 }
 
 // UnmarshalSQL reads an sql response into the url receiver
@@ -525,48 +671,4 @@ func (u *Url) UnmarshalSQL(row sqlutil.Scannable) (err error) {
 	}
 
 	return nil
-}
-
-// SQLArgs formats a url struct for inserting / updating into postgres
-func (u *Url) SQLArgs() []interface{} {
-	headerBytes, err := json.Marshal(u.Headers)
-	if err != nil {
-		panic(err)
-	}
-	metaBytes, err := json.Marshal(u.Meta)
-	if err != nil {
-		panic(err)
-	}
-
-	lastGet := u.LastGet
-	if lastGet != nil {
-		utc := lastGet.In(time.UTC)
-		lastGet = &utc
-	}
-
-	lastHead := u.LastHead
-	if lastHead != nil {
-		utc := lastHead.In(time.UTC)
-		lastHead = &utc
-	}
-
-	return []interface{}{
-		u.Url,
-		u.Created.In(time.UTC),
-		u.Updated.In(time.UTC),
-		lastHead,
-		lastGet,
-		u.Status,
-		u.ContentType,
-		u.ContentSniff,
-		u.ContentLength,
-		u.FileName,
-		u.Title,
-		u.Id,
-		u.HeadersTook,
-		u.DownloadTook,
-		headerBytes,
-		metaBytes,
-		u.Hash,
-	}
 }

--- a/url_test.go
+++ b/url_test.go
@@ -1,27 +1,29 @@
 package archive
 
 import (
-	"fmt"
+	// "fmt"
+	"github.com/archivers-space/sql_datastore"
+	"github.com/ipfs/go-datastore"
 	"testing"
 )
 
 func TestUrlStorage(t *testing.T) {
-	defer resetTestData(appDB, "urls", "links")
+	store := datastore.NewMapDatastore()
 
 	u := &Url{Url: "http://youtube.com"}
-	if err := u.Insert(appDB); err != nil {
+	if err := u.Insert(store); err != nil {
 		t.Error(err.Error())
 		return
 	}
 
 	u.ContentLength = 10
-	if err := u.Update(appDB); err != nil {
+	if err := u.Update(store); err != nil {
 		t.Error(err.Error())
 		return
 	}
 
-	u2 := &Url{Url: "http://youtube.com"}
-	if err := u2.Read(appDB); err != nil {
+	u2 := &Url{Id: u.Id}
+	if err := u2.Read(store); err != nil {
 		t.Error(err.Error())
 		return
 	}
@@ -34,7 +36,48 @@ func TestUrlStorage(t *testing.T) {
 		t.Errorf("updated doesn't match: %s != %s", u2.Updated.String(), u.Updated.String())
 	}
 
-	if err := u.Delete(appDB); err != nil {
+	if err := u.Delete(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+}
+
+func TestUrlSQLStorage(t *testing.T) {
+	defer resetTestData(appDB, "urls", "links")
+
+	store := sql_datastore.NewDatastore(appDB)
+	if err := store.Register(&Url{}); err != nil {
+		t.Error(err)
+		return
+	}
+
+	u := &Url{Url: "http://youtube.com"}
+	if err := u.Insert(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	u.ContentLength = 10
+	if err := u.Update(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	u2 := &Url{Url: "http://youtube.com"}
+	if err := u2.Read(store); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	if !u2.Created.Equal(u.Created) {
+		t.Errorf("created doesn't match: %s != %s", u2.Created.String(), u.Created.String())
+	}
+
+	if !u2.Updated.Equal(u.Updated) {
+		t.Errorf("updated doesn't match: %s != %s", u2.Updated.String(), u.Updated.String())
+	}
+
+	if err := u.Delete(store); err != nil {
 		t.Error(err.Error())
 		return
 	}
@@ -43,8 +86,14 @@ func TestUrlStorage(t *testing.T) {
 func TestShouldEnqueue(t *testing.T) {
 	defer resetTestData(appDB, "urls")
 
+	store := sql_datastore.NewDatastore(appDB)
+	if err := store.Register(&Url{}); err != nil {
+		t.Error(err)
+		return
+	}
+
 	epa := &Url{Url: "http://www.epa.gov"}
-	if err := epa.Read(appDB); err != nil {
+	if err := epa.Read(store); err != nil {
 		t.Fatal(err.Error())
 	}
 
@@ -73,25 +122,25 @@ func TestShouldEnqueue(t *testing.T) {
 	}
 }
 
-func TestUrlGet(t *testing.T) {
-	u := &Url{Url: "https://www.apple.com"}
-	done := make(chan bool, 0)
-	links, err := u.Get(appDB, func(err error) {
-		if err != nil {
-			fmt.Println(err.Error())
-		}
-		done <- true
-	})
+// func TestUrlGet(t *testing.T) {
+// 	u := &Url{Url: "https://www.apple.com"}
+// 	done := make(chan bool, 0)
+// 	links, err := u.Get(appDB, func(err error) {
+// 		if err != nil {
+// 			fmt.Println(err.Error())
+// 		}
+// 		done <- true
+// 	})
 
-	if err != nil {
-		t.Error(err.Error())
-	}
+// 	if err != nil {
+// 		t.Error(err.Error())
+// 	}
 
-	if len(links) == 0 {
-		t.Error("didn't find any links?")
-	}
-	<-done
-}
+// 	if len(links) == 0 {
+// 		t.Error("didn't find any links?")
+// 	}
+// 	<-done
+// }
 
 func TestUrlSuspectedContentUrl(t *testing.T) {
 	cases := []struct {

--- a/urls_test.go
+++ b/urls_test.go
@@ -1,0 +1,33 @@
+package archive
+
+import (
+	"github.com/archivers-space/sql_datastore"
+	"testing"
+)
+
+func TestListUrls(t *testing.T) {
+	resetTestData(appDB, "urls")
+
+	store := sql_datastore.NewDatastore(appDB)
+	if err := store.Register(&Url{}); err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	urls, err := ListUrls(store, 20, 0)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if len(urls) != 3 {
+		t.Errorf("urls length mismatch")
+	}
+
+	urls, err = ListUrls(store, 20, 10)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if len(urls) != 0 {
+		t.Errorf("urls length mismatch")
+	}
+}


### PR DESCRIPTION
Story time!
*tl;dr; this sets us up to do all sorts of cool shit with IPFS down the road, and makes testing better now*

This PR originated with [failing tests on the identity server](https://circleci.com/gh/archivers-space/identity). Previously this code was all in one package, but needed to be broken up in order to support remote procedure calls between servers (and for better encapsulation). Before this separation the package used an actual Postgres database connection to run it's tests. I'm a fan of testing against a real database because it's closer to what happens in production. The issue is, go runs different package test suites in parallel, so when the tests are broken up into separate packages, the tests start manipulating entries in the same database at the same time, causing unpredictable results. There are a few ways to fix this:

1. Spin up a database for each test suite
2. Mock the database
3. Abstract the storage layer, moving the Postgres tests up into the same package

First one just feels gross and slow to me. The second is a viable alternative, but the overhead of maintaining mocked database tests is rather high. I've done it in the past using [data-dog's sql-mock](https://github.com/DATA-DOG/go-sqlmock) and found it irritating, and didn't weed out nasty production bugs specific to, say Postgres 9.6.

So I got to thinking about the third option, and I was all "well at some point we might want a caching layer" (something like redis) because already the urls table is around 7M entries and takes forever to respond, so it would make sense to start thinking in the abstract about writing to an abstract "store", instead of "Postgres", and then I was all WHAT IF THE STORE WAS A DISTRIBUTED INTERNETS!?

So, to be clear, in a lot of places writing to IPFS doesn't make any sense, but in some it really, really does. For example, our web crawler sentry currently crawls & writes to a Postgres database, which we're thinking will eventually get packaged up & written to IPFS, the next feature for sentry is crawling JSON-LD files like data.gov, this PR sets up a world where we're _crawling directly to the distributed web_, creating a distributed, continuously updated data.gov.

So in order to do that we would need a bridge between the [ipfs-datastore interface](https://github.com/ipfs/go-datastore) and SQL, which I've written a cursory version of here: [sql_datastore](https://github.com/archivers-space/go-sql-datastore). That one even has documentation. This means we'll have toll-free writing to IPFS for all of our stuff, and our tests can use the datastore.MapDatastore() for unit tests, and move the Postgres tests up to top level packages. I've intentionally made the the package very specific because I don't want to spend too much time on this right now, as the pifs-datastore interface itself may change in the future. This does, however, make me more suited to provide input to the Protocol Labs team on the interface itself, using real-world examples.  

This also means that we can use more off-the-shelf code that implements the ipfs-datastore interface, and contribute to those projects in the process.

So, why is this a terrible idea? Well, it complicates the code, which makes it harder for others to understand, but it is much easier to write tests for that code, because you no longer need a database to do so. So with this I'll do what I can to up my documentation of what's going on for others to be able to grok.

cc @flyingzumwalt